### PR TITLE
scripts: headers_install: Rename sigaction definition

### DIFF
--- a/scripts/headers_install.sh
+++ b/scripts/headers_install.sh
@@ -36,6 +36,7 @@ sed -E -e '
 	s/(^|[^a-zA-Z0-9])__packed([^a-zA-Z0-9_]|$)/\1__attribute__((packed))\2/g
 	s/(^|[[:space:](])(inline|asm|volatile)([[:space:](]|$)/\1__\2__\3/g
 	s@#(ifndef|define|endif[[:space:]]*/[*])[[:space:]]*_UAPI@#\1 @
+	s/struct sigaction/struct __kernel_sigaction/g
 ' $INFILE > $TMPFILE || exit 1
 
 scripts/unifdef -U__KERNEL__ -D__EXPORTED_HEADERS__ $TMPFILE > $OUTFILE


### PR DESCRIPTION
After the "Avoid multiple definitions of sigaction." change in bionic, we ought to modify our kernel headers to make sure that sigaction struct is not present in uapi headers.

Change-Id: I9d668467a74aa2f5ea2e1ae15b6b6a5f546f47ff

## Summary by Sourcery

Enhancements:
- Rename the 'sigaction' struct to '__kernel_sigaction' in the kernel headers to avoid conflicts with bionic's definitions.